### PR TITLE
Suppress empty lines

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source/DALI/dali_interface"]
 	path = source/DALI/dali_interface
-	url = git@github.com:SvenHaedrich/dali_interface.git
+	url = https://github.com/sevenlab-de/dali_interface.git

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 This script converts DALI codes into human readable messages. DALI is the digital addressable lighting interface as described [here](https://www.dali-alliance.org).
 
 The source for the DALI code aka frames can be one of
+
 * stdin
 * HID class DALI / USB converter (e.g. [Lunatone](https://www.lunatone.com/produkt/dali-usb/))
 
 This script is based on the following standards
+
 * IEC 62386-101:2022 system components
 * IEC 62386-102:2022 control gear
 * IEC 62386-103:2022 control device

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+# Changelog for `dali_mon`
+
+## Version 1.7.0
+
+- Generate no output when lines without DALI information are encountered
+- Support --echo for piped file input. Fixes: <https://github.com/SvenHaedrich/dali_mon/issues/32>
+- Fixes: <https://github.com/SvenHaedrich/dali_mon/issues/31>

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Install
 
-    git clone git@github.com:SvenHaedrich/dali_mon.git
+    git clone https://github.com/SvenHaedrich/dali_mon.git
     cd dali_mon
     git submodule update --init
 

--- a/source/DALI/backframe_8bit.py
+++ b/source/DALI/backframe_8bit.py
@@ -1,5 +1,6 @@
 from typeguard import typechecked
 
+
 @typechecked
 class Backframe8Bit:
     LENGTH = 8

--- a/source/DALI/forward_frame_25bit.py
+++ b/source/DALI/forward_frame_25bit.py
@@ -195,7 +195,7 @@ class ForwardFrame25Bit:
             return
         if address_byte == 0xA3:
             self.address = f"C{class_byte:1d}"
-            self.command = f"QUERY CONTROL CLASS (0x{(opcode_byte & 0xf):1X}) = {(opcode_byte & 0xf)}"
+            self.command = f"QUERY CONTROL CLASS (0x{(opcode_byte & 0xF):1X}) = {(opcode_byte & 0xF)}"
             return
         if address_byte == 0xA5:
             if opcode_byte == 0:

--- a/source/dali_mon.py
+++ b/source/dali_mon.py
@@ -6,9 +6,7 @@ import click
 import datetime
 from termcolor import cprint
 
-from DALI.dali_interface.dali_interface import DaliInterface, DaliFrame, DaliStatus
-from DALI.dali_interface.serial import DaliSerial
-from DALI.dali_interface.hid import DaliUsb
+from DALI.dali_interface.dali_interface import DaliInterface, DaliFrame, DaliSerial, DaliStatus, DaliUsb
 from DALI.forward_frame_16bit import DeviceType
 from DALI.decode import Decode
 
@@ -43,7 +41,9 @@ def print_error(
     cprint(f"{message}", color="red")
 
 
-def process_line(frame: DaliFrame, absolute_time: float) -> None:
+def process_line(frame: DaliFrame|None, absolute_time: float) -> None:
+    if frame is None:
+        return
     if process_line.last_timestamp != 0:
         delta_s = frame.timestamp - process_line.last_timestamp
     else:
@@ -82,11 +82,14 @@ def main_connection(
 def main_tty(transparent: bool, absolute_time: bool) -> None:
     logger.debug("read from tty device")
     line = ""
+    sys.stdin.reconfigure(encoding="ascii", errors="ignore")
     while True:
         line = line + sys.stdin.readline()
         if len(line) > 0 and line[-1] == "\n":
             line = line.strip(" \r\n")
             if len(line) > 0:
+                if transparent:
+                    print(line)
                 frame = DaliSerial.parse(line)
                 process_line(frame, absolute_time)
             line = ""
@@ -101,7 +104,7 @@ def main_file(transparent: bool, absolute_time: bool) -> None:
 
 
 @click.command()
-@click.version_option("1.6.0")
+@click.version_option("1.7.0")
 @click.option(
     "-l",
     "--hid",
@@ -128,7 +131,7 @@ def dali_mon(
 ):
     """
     Monitor for DALI commands.
-    sevenlab engineering 2025
+    sevenlab engineering 2026
     """
     if debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/source/dali_mon.py
+++ b/source/dali_mon.py
@@ -6,7 +6,13 @@ import click
 import datetime
 from termcolor import cprint
 
-from DALI.dali_interface.dali_interface import DaliInterface, DaliFrame, DaliSerial, DaliStatus, DaliUsb
+from DALI.dali_interface.dali_interface import (
+    DaliInterface,
+    DaliFrame,
+    DaliSerial,
+    DaliStatus,
+    DaliUsb,
+)
 from DALI.forward_frame_16bit import DeviceType
 from DALI.decode import Decode
 
@@ -41,7 +47,7 @@ def print_error(
     cprint(f"{message}", color="red")
 
 
-def process_line(frame: DaliFrame|None, absolute_time: float) -> None:
+def process_line(frame: DaliFrame | None, absolute_time: float) -> None:
     if frame is None:
         return
     if process_line.last_timestamp != 0:
@@ -128,9 +134,7 @@ def main_file(transparent: bool, absolute_time: bool) -> None:
     show_envvar=True,
     type=click.Path(),
 )
-def dali_mon(
-    hid, debug, echo, absolute, serial_port, on, off
-):
+def dali_mon(hid, debug, echo, absolute, serial_port, on, off):
     """
     Monitor for DALI commands.
     sevenlab engineering 2026

--- a/source/dali_mon.py
+++ b/source/dali_mon.py
@@ -99,6 +99,8 @@ def main_file(transparent: bool, absolute_time: bool) -> None:
     logger.debug("read from file")
     for line in sys.stdin:
         if len(line) > 0:
+            if transparent:
+                print(line, end="")
             frame = DaliSerial.parse(line)
             process_line(frame, absolute_time)
 

--- a/source/tests/mon/test_103.py
+++ b/source/tests/mon/test_103.py
@@ -281,28 +281,29 @@ def test_initialise_short_address():
 def test_initialise_special_cases(test_data, target_cmd):
     build_24bit_frame_and_test(test_data, "", target_cmd)
 
+
 """ see iec 62386-103:2022 Table 1: 24-bit command frame encoding """
+
+
 @pytest.mark.parametrize(
-        "address_byte",
-        [
-            (0b11100001),
-            (0b11100011),
-            (0b11100101),
-            (0b11100111),
-            (0b11101001),
-            (0b11101011),
-            (0b11101101),
-            (0b11101111),
-            (0b11110001),
-            (0b11110011),
-            (0b11110101),
-            (0b11110111),
-            (0b11111001),
-            (0b11111011),
-        ]
+    "address_byte",
+    [
+        (0b11100001),
+        (0b11100011),
+        (0b11100101),
+        (0b11100111),
+        (0b11101001),
+        (0b11101011),
+        (0b11101101),
+        (0b11101111),
+        (0b11110001),
+        (0b11110011),
+        (0b11110101),
+        (0b11110111),
+        (0b11111001),
+        (0b11111011),
+    ],
 )
 def test_reserved_command_spaces(address_byte):
-    test_data = (address_byte << 16) 
+    test_data = address_byte << 16
     build_24bit_frame_and_test(test_data, "", "RESERVED")
-
-    

--- a/source/tests/mon/test_serial.py
+++ b/source/tests/mon/test_serial.py
@@ -1,5 +1,4 @@
-from DALI.dali_interface.dali_interface import DaliStatus
-from DALI.dali_interface.serial import DaliSerial
+from DALI.dali_interface.dali_interface import DaliStatus, DaliSerial
 
 
 def test_raw_from_string():
@@ -33,3 +32,21 @@ def test_raw_from_string():
     assert result.length == 0x20
     assert result.data == 0x87654321
     assert result.status == DaliStatus.FRAME
+    input_string = "*** Booting Zephyr OS build v4.4.0-5197-g6f49860fc7a2 ***"
+    result = DaliSerial.parse(input_string)
+    assert result is None
+    input_string = "aa{bb"
+    result = DaliSerial.parse(input_string)
+    assert result is None
+    input_string = "aa}bb"
+    result = DaliSerial.parse(input_string)
+    assert result is None
+    input_string = "aa}{bb"
+    result = DaliSerial.parse(input_string)
+    assert result is None
+    input_string = "{aa}"
+    result = DaliSerial.parse(input_string)
+    assert result is None
+    input_string = "{00000004:op 87654321}"
+    result = DaliSerial.parse(input_string)
+    assert result is None


### PR DESCRIPTION
Generate no output when lines without DALI information are encountered. So, that input like this:

```
[00:00:07.715,423] <inf> D: {00001e23:10 0000ff00}
[00:00:09.721,984] <inf> D: {000025f9:10 0000ff05}
[00:00:11.727,386] <inf> D: {00002dcf:10 0000ff00}
*** Booting Zephyr OS build v4.4.0-5197-g6f49860fc7a2 ***
[00:00:01.995,330] <inf> D: {000007cb:10 0000ff00}
[00:00:03.998,840] <inf> D: {00000f9e:10 0000ff05}
```
Doesn`t throw error messages.